### PR TITLE
Generate an error when credentials are not available in batch mode

### DIFF
--- a/+Hakai/@Client/Client.m
+++ b/+Hakai/@Client/Client.m
@@ -29,6 +29,8 @@ classdef Client
 
        if isstruct(cred)
          obj.credentials = cred;
+       elseif batchStartupOptionUsed
+           error('Credentials expired or not available!')
        else
          cred = obj.get_credentials_from_web();
          obj.save_credentials(cred);


### PR DESCRIPTION
The client is sometimes used within some cron projects where no user is actively using the interface. 

The present change generate an error when the following conditions are met:
1. MatLab is run from the terminal with the flag -batch activated
2. A Hakai API token is not available or expired. 

This will generate a more clear error about the issue encountered.